### PR TITLE
sstd::terp, adding the reference support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ sstd/include/
 sstd/lib/
 sstd/tmpMake/
 backup/
+.*
 
 tmpDir/
 tmp*/

--- a/docker/alpine/rm_docker_image.sh
+++ b/docker/alpine/rm_docker_image.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+IMAGE_ID=$(docker images | grep 'sstd_alpine' | awk '{print $3}')
+echo $IMAGE_ID
+docker rmi ${IMAGE_ID}

--- a/sstd/src/memory/terp/terp.cpp
+++ b/sstd/src/memory/terp/terp.cpp
@@ -169,25 +169,25 @@ std::string _format(double rhs){
 }
 
 // constructors
-sstd::terp::var::var():                      _type(sstd::num_null), _p(NULL) {}
-sstd::terp::var::var(const class var&  rhs): _type(sstd::num_null), _p(NULL) { copy(rhs); }
-sstd::terp::var::var(      class var&& rhs): _type(sstd::num_null), _p(NULL) { free(); move(std::move(rhs)); }
-sstd::terp::var::var(        bool         rhs){ _type=sstd::num_str; _p=new std::string(rhs?"true":"false"); }
-sstd::terp::var::var(        char         rhs){ _type=sstd::num_str; _p=new std::string({rhs}); }
-sstd::terp::var::var(        int8         rhs){ _type=sstd::num_str; _p=new std::string(sstd::ssprintf("%d", rhs)); }
-sstd::terp::var::var(        int16        rhs){ _type=sstd::num_str; _p=new std::string(sstd::ssprintf("%d", rhs)); }
-sstd::terp::var::var(        int32        rhs){ _type=sstd::num_str; _p=new std::string(sstd::ssprintf("%d", rhs)); }
-sstd::terp::var::var(        int64        rhs){ _type=sstd::num_str; _p=new std::string(sstd::ssprintf("%ld", rhs)); }
-sstd::terp::var::var(       uint8         rhs){ _type=sstd::num_str; _p=new std::string(sstd::ssprintf("%u", rhs)); }
-sstd::terp::var::var(       uint16        rhs){ _type=sstd::num_str; _p=new std::string(sstd::ssprintf("%u", rhs)); }
-sstd::terp::var::var(       uint32        rhs){ _type=sstd::num_str; _p=new std::string(sstd::ssprintf("%u", rhs)); }
-sstd::terp::var::var(       uint64        rhs){ _type=sstd::num_str; _p=new std::string(sstd::ssprintf("%lu", rhs)); }
-sstd::terp::var::var(        float        rhs){ _type=sstd::num_str; _p=new std::string(sstd::ssprintf(_format(rhs).c_str(), rhs)); }
-sstd::terp::var::var(       double        rhs){ _type=sstd::num_str; _p=new std::string(sstd::ssprintf(_format(rhs).c_str(), rhs)); }
-sstd::terp::var::var(const char*        rhs): _type(sstd::num_str), _p(new std::string(rhs)) {}
-sstd::terp::var::var(const std::string& rhs){ _type=sstd::num_str; _p=new std::string(rhs); }
+sstd::terp::var::var():                      _is_reference(false), _type(sstd::num_null), _p(NULL) {}
+sstd::terp::var::var(const class var&  rhs): _is_reference(false), _type(sstd::num_null), _p(NULL) { copy(rhs); }
+sstd::terp::var::var(      class var&& rhs): _is_reference(false), _type(sstd::num_null), _p(NULL) { free(); move(std::move(rhs)); }
+sstd::terp::var::var(        bool       rhs){ _is_reference=false; _type=sstd::num_str; _p=new std::string(rhs?"true":"false"); }
+sstd::terp::var::var(        char       rhs){ _is_reference=false; _type=sstd::num_str; _p=new std::string({rhs}); }
+sstd::terp::var::var(        int8       rhs){ _is_reference=false; _type=sstd::num_str; _p=new std::string(sstd::ssprintf("%d", rhs)); }
+sstd::terp::var::var(        int16      rhs){ _is_reference=false; _type=sstd::num_str; _p=new std::string(sstd::ssprintf("%d", rhs)); }
+sstd::terp::var::var(        int32      rhs){ _is_reference=false; _type=sstd::num_str; _p=new std::string(sstd::ssprintf("%d", rhs)); }
+sstd::terp::var::var(        int64      rhs){ _is_reference=false; _type=sstd::num_str; _p=new std::string(sstd::ssprintf("%ld", rhs)); }
+sstd::terp::var::var(       uint8       rhs){ _is_reference=false; _type=sstd::num_str; _p=new std::string(sstd::ssprintf("%u", rhs)); }
+sstd::terp::var::var(       uint16      rhs){ _is_reference=false; _type=sstd::num_str; _p=new std::string(sstd::ssprintf("%u", rhs)); }
+sstd::terp::var::var(       uint32      rhs){ _is_reference=false; _type=sstd::num_str; _p=new std::string(sstd::ssprintf("%u", rhs)); }
+sstd::terp::var::var(       uint64      rhs){ _is_reference=false; _type=sstd::num_str; _p=new std::string(sstd::ssprintf("%lu", rhs)); }
+sstd::terp::var::var(        float      rhs){ _is_reference=false; _type=sstd::num_str; _p=new std::string(sstd::ssprintf(_format(rhs).c_str(), rhs)); }
+sstd::terp::var::var(       double      rhs){ _is_reference=false; _type=sstd::num_str; _p=new std::string(sstd::ssprintf(_format(rhs).c_str(), rhs)); }
+sstd::terp::var::var(const char*        rhs){ _is_reference=false; _type=sstd::num_str; _p=new std::string(rhs); }
+sstd::terp::var::var(const std::string& rhs){ _is_reference=false; _type=sstd::num_str; _p=new std::string(rhs); }
 
-sstd::terp::var::~var(){ sstd::terp::var::free(); }
+sstd::terp::var::~var(){ if(!_is_reference){sstd::terp::var::free();} }
 
 //---
 /*
@@ -320,6 +320,12 @@ void sstd::terp::var::free(){
 
 sstd::terp::var& sstd::terp::var::operator=(const sstd::terp::var& rhs){
     copy(rhs);
+    return *this;
+}
+sstd::terp::var& sstd::terp::var::operator=(const sstd::terp::var* rhs){
+    this->_is_reference = true;
+    this->_type         = rhs->type();
+    this->_p            = rhs->p();
     return *this;
 }
 

--- a/sstd/src/memory/terp/terp.hpp
+++ b/sstd/src/memory/terp/terp.hpp
@@ -62,6 +62,7 @@ namespace sstd::terp{
 
 class sstd::terp::var{
 private:
+    bool _is_reference;
     uint _type;
     void* _p;
     
@@ -108,6 +109,7 @@ public:
     //var operator=(      sstd::terp::var&& rhs);
     
     var& operator=(const char* rhs);
+    var& operator=(const  var* rhs); // for the reference of var address. // Note: sstd::terp did NOT mention the trouble with circular reference.
 
     bool operator==(const sstd::terp::var& rhs);
     bool operator!=(const sstd::terp::var& rhs);

--- a/sstd/src/python/c2py.hpp
+++ b/sstd/src/python/c2py.hpp
@@ -235,7 +235,7 @@ inline void sstd_c2py::operator_brackets(T& ret, const char* writeDir_base, cons
     }else if(sstd::fileExist("/usr/include/sstd/src/python/c2py.py"  )){ path_to_c2py_py = "/usr/include/sstd/src/python/c2py.py";
     }else if(sstd::fileExist("./c2py.py"                             )){ path_to_c2py_py = "./c2py.py";
     }                               else                               { sstd::pdbg_err("\"c2py.py\" is not found."); return; }
-    if(system(sstd::ssprintf("python -u %s %s %s %s", path_to_c2py_py.c_str(), writeDir_base, iFile, fName).c_str())!=0){ sstd::pdbg_err("system() was failed.\n"); return; }
+    if(system(sstd::ssprintf("python3 -u %s %s %s %s", path_to_c2py_py.c_str(), writeDir_base, iFile, fName).c_str())!=0){ sstd::pdbg_err("system() was failed.\n"); return; }
     
     // write back non const pointer args.
         // read "argList.bin"

--- a/sstd/src/string/strEdit.cpp
+++ b/sstd/src/string/strEdit.cpp
@@ -591,7 +591,7 @@ void        sstd::stripAll_ow(      std::string& str, const std::string& stripLi
 //-----------------------------------------------------------------------------------------------------------------------------------------------
 
 std::string sstd::strip_quotes(bool& ret_sq, bool& ret_dq, const        char* str){
-    return std::move(sstd::strip_quotes(ret_sq, ret_dq, std::string(str)));
+    return sstd::strip_quotes(ret_sq, ret_dq, std::string(str));
 }
 std::string sstd::strip_quotes(bool& ret_sq, bool& ret_dq, const std::string& str){
     ret_dq=false;

--- a/test/src_test/file/yaml.cpp
+++ b/test/src_test/file/yaml.cpp
@@ -2841,14 +2841,14 @@ TEST(yaml, double_quotation_list_NUM_LIST_case02){ // WIP
    def"
 )";
     sstd::terp::var yml; ASSERT_TRUE(sstd::yaml_load(yml, s)); // TEST THIS LINE
-    sstd::printn(yml);
+    //sstd::printn(yml);
 
     //---
     
     sstd::terp::var ans;
     ans = sstd::terp::list(1);
     ans[0] = "abcdef";
-    sstd::printn(ans);
+    //sstd::printn(ans);
     
     //---
     

--- a/test/src_test/memory/terp/terp.cpp
+++ b/test/src_test/memory/terp/terp.cpp
@@ -800,5 +800,33 @@ TEST(memory_terp, isValue_false){
 }
 
 //-----------------------------------------------------------------------------------------------------------------------------------------------
+// referendce of the `sstd::terp::var` address
+
+TEST(memory_terp, reference_of_sstd_terp_var_01){
+    sstd::terp::var x;
+    x = sstd::terp::list(2);
+    x[0] = sstd::terp::list(3);
+    x[0][0] = "a";
+    x[0][1] = "b";
+    x[0][2] = "c";
+    x[1] = &x[0];
+    //sstd::printn(x);
+    
+    sstd::terp::var a; // ans
+    a = sstd::terp::list(2);
+    a[0] = sstd::terp::list(3);
+    a[0][0] = "a";
+    a[0][1] = "b";
+    a[0][2] = "c";
+    a[1] = sstd::terp::list(3);
+    a[1][0] = "a";
+    a[1][1] = "b";
+    a[1][2] = "c";
+    //sstd::printn(a);
+    
+    ASSERT_TRUE(x==a);
+}
+
+//-----------------------------------------------------------------------------------------------------------------------------------------------
 
 EXECUTE_TESTS();


### PR DESCRIPTION
Changes:

1. Appending the reference support to `sstd::terp::var` like following:
```cpp
TEST(memory_terp, reference_of_sstd_terp_var_01){
    sstd::terp::var x;
    x = sstd::terp::list(2);
    x[0] = sstd::terp::list(3);
    x[0][0] = "a";
    x[0][1] = "b";
    x[0][2] = "c";
    x[1] = &x[0];
    //sstd::printn(x);
    
    sstd::terp::var a; // ans
    a = sstd::terp::list(2);
    a[0] = sstd::terp::list(3);
    a[0][0] = "a";
    a[0][1] = "b";
    a[0][2] = "c";
    a[1] = sstd::terp::list(3);
    a[1][0] = "a";
    a[1][1] = "b";
    a[1][2] = "c";
    //sstd::printn(a);
    
    ASSERT_TRUE(x==a);
}
```
2. Changing the base Python version at `sstd::c2py()` from `Python` to `Python3` to fix the error of CI/CD pipeline (GitHub Actions workflow). Note: The latest Alpine linux removes the `Python` package.